### PR TITLE
Refine database proposal and configure npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # ERP
 Anagrafica clienti, anagrafica prodotti, gestione incassi e statistiche
+
+Per una proposta di struttura del database e delle API vedi [docs/db-api-proposal.md](docs/db-api-proposal.md).

--- a/docs/db-api-proposal.md
+++ b/docs/db-api-proposal.md
@@ -1,0 +1,47 @@
+# Proposta Database e API
+
+Questa proposta descrive una possibile struttura del database relazionale e delle API REST per l'applicazione ERP.
+
+## Struttura del database
+
+### Tabelle principali
+
+- **users**: id, username, password_hash, role (`ADMIN`/`MANAGER`)
+- **clients**: id, nome, cognome, email, telefono, indirizzo
+- **products**: id, nome, descrizione, premio_annuo
+- **payments**: id, client_id, product_id, importo, data_pagamento, metodo
+- **reports**: non una tabella dedicata, ma viste/aggregazioni sui dati esistenti.
+
+### Relazioni
+
+- `payments.client_id` → `clients.id`
+- `payments.product_id` → `products.id`
+
+## API REST
+
+| Metodo | Endpoint | Descrizione | Ruolo |
+|--------|----------|-------------|-------|
+| POST   | /api/auth/login | Autenticazione utente | pubblico |
+| GET    | /api/users | Elenco profili | ADMIN |
+| POST   | /api/users | Creazione profilo | ADMIN |
+| PUT    | /api/users/:id | Aggiornamento profilo | ADMIN |
+| DELETE | /api/users/:id | Eliminazione profilo | ADMIN |
+| GET    | /api/clients | Elenco clienti | ADMIN/MANAGER |
+| POST   | /api/clients | Nuovo cliente | ADMIN/MANAGER |
+| PUT    | /api/clients/:id | Aggiornamento cliente | ADMIN/MANAGER |
+| DELETE | /api/clients/:id | Eliminazione cliente | ADMIN |
+| GET    | /api/products | Elenco prodotti | ADMIN/MANAGER |
+| POST   | /api/products | Nuovo prodotto | ADMIN |
+| PUT    | /api/products/:id | Aggiornamento prodotto | ADMIN |
+| DELETE | /api/products/:id | Eliminazione prodotto | ADMIN |
+| GET    | /api/payments | Elenco incassi | ADMIN/MANAGER |
+| POST   | /api/payments | Registrazione incasso | ADMIN/MANAGER |
+| GET    | /api/reports/summary | Reportistica aggregata | ADMIN/MANAGER |
+
+## Tecnologie suggerite
+
+- **Backend**: Node.js con framework NestJS
+- **Database**: MySQL
+- **Autenticazione**: JWT con refresh token
+- **Migrazioni**: TypeORM per gestire schema e versioning
+


### PR DESCRIPTION
## Summary
- clarify tech stack: NestJS backend, MySQL database, JWT auth with refresh tokens, TypeORM migrations
- add `.npmrc` pointing to the public npm registry to avoid 403 errors when installing tools

## Testing
- `npx -y markdownlint docs/db-api-proposal.md` *(fails: 403 Forbidden from registry)*
- `npx @angular/cli@latest new frontend --routing --style=scss --no-standalone --skip-git --package-manager npm --directory /tmp/frontend` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68906b319e348327a768bd726d4f0b8f